### PR TITLE
when startsWith comparing with a list with more bytes should return false

### DIFF
--- a/src/org/jruby/util/ByteList.java
+++ b/src/org/jruby/util/ByteList.java
@@ -890,6 +890,7 @@ public final class ByteList implements Comparable, CharSequence, Serializable {
 
     public boolean startsWith(ByteList other, int toffset) {
         if (realSize == 0) return false;
+        if(this.bytes().length < other.bytes().length) return false;
 
         byte[]ta = bytes;
         int to = begin + toffset;

--- a/test/org/jruby/util/ByteListTest.java
+++ b/test/org/jruby/util/ByteListTest.java
@@ -463,4 +463,14 @@ public class ByteListTest extends TestCase {
         assertEquals(0, bl.getBegin());
         assertEquals(50, bl.getRealSize());
     }
+
+    public void testStartsWithReturnFalseWhenComparedListHasMoreBytes() {
+    	ByteList file_url_start = ByteList.create("file:");
+    	ByteList f = ByteList.create("f");
+    	try {
+    		f.startsWith(file_url_start);
+    	} catch (Exception ex) {
+    		fail("shouldn't have thrown exception");
+    	}
+    }
 }


### PR DESCRIPTION
startsWith is throwing ArrayIndexOutOfBounds when comparing with a list that has more bytes. Caught that while fixing the build for this commit in jruby

https://github.com/jruby/jruby/commit/de01d3a30d4e86eee608d51363108f5d23ff7a01
