### PR TITLE
Fix two problems in ByteList#startsWith

### DIFF
--- a/src/org/jruby/util/ByteList.java
+++ b/src/org/jruby/util/ByteList.java
@@ -888,7 +888,7 @@ public final class ByteList implements Comparable, CharSequence, Serializable {
     }
 
     public boolean startsWith(ByteList other, int toffset) {
-        if (realSize == 0 || this.bytes().length < other.bytes().length) return false;
+        if (realSize == 0 || this.realSize < other.realSize + toffset) return false;
 
         byte[]ta = bytes;
         int to = begin + toffset;

--- a/test/org/jruby/util/ByteListTest.java
+++ b/test/org/jruby/util/ByteListTest.java
@@ -402,7 +402,13 @@ public class ByteListTest extends TestCase {
         assertFalse(blank.startsWith(str));
         assertFalse(blankAndZeroLength.startsWith(str));
     }
-    
+
+    public void testStartsWithWithOffset() {
+        ByteList str = new ByteList("xxxx".getBytes());
+
+        assertFalse(str.startsWith(str, 1));
+    }
+
     public void testConstructorsSetEncoding() {
         ByteList utf8 = new ByteList(new byte[0], UTF8Encoding.INSTANCE);
         assertEquals(UTF8Encoding.INSTANCE, utf8.getEncoding());


### PR DESCRIPTION
First problem is that the offset is not taken into account when short-
circuiting on length, which can lead to ArrayIndexOutOfBoundsException.

The second problem was that instead of reading the real sizes, the code
was making copies of both byte arrays involved in a startsWith check,
just to obtain the length.
